### PR TITLE
Fixing links

### DIFF
--- a/Editor_With_Toolbox/Readme.md
+++ b/Editor_With_Toolbox/Readme.md
@@ -24,11 +24,9 @@ Goals:
 
 **Requirements**
 
-[ Visual Studio 2015 ](http://www.microsoft.com/visualstudio/en-
-us/try/default.mspx#download)
+[ Visual Studio 2015 ](http://www.microsoft.com/visualstudio/en-us/try/default.mspx#download)
 
-[ Visual Studio 2015 SDK ](https://www.visualstudio.com/en-us/downloads
-/visual-studio-2015-downloads-vs.aspx)
+[ Visual Studio 2015 SDK ](https://www.visualstudio.com/en-us/downloads/visual-studio-2015-downloads-vs.aspx)
 
 
 
@@ -68,14 +66,11 @@ and supports drag and drop text from the toolbox.
 
 **Related topics**
 
-* [ Toolbox Documentation ](https://msdn.microsoft.com/en-
-us/library/ee712574(v=vs.140).aspx)
+* [ Toolbox Documentation ](https://msdn.microsoft.com/en-us/library/ee712574(v=vs.140).aspx)
 
-* [ Editor Documentation ](https://msdn.microsoft.com/en-
-us/library/dd885242(v=vs.140).aspx)
+* [ Editor Documentation ](https://msdn.microsoft.com/en-us/library/dd885242(v=vs.140).aspx)
 
-* [ Visual Studio SDK Documentation ](https://msdn.microsoft.com/en-
-us/library/bb166441(v=vs.140).aspx)
+* [ Visual Studio SDK Documentation ](https://msdn.microsoft.com/en-us/library/bb166441(v=vs.140).aspx)
 
 
 


### PR DESCRIPTION
Maybe you need also to remove Visual Studio 2015 RC Download because is the unique that appear on search and sure many people will tend to download it, or provide also final SDK as standalone

http://www.microsoft.com/en-us/download/details.aspx?id=46850