### PR TITLE
Fix 1208279 - [Sample] WPFDesigner_XML extention is not functioning

### DIFF
--- a/WPFDesigner_XML/WPFDesigner_XML/WPFDesigner_XML.csproj
+++ b/WPFDesigner_XML/WPFDesigner_XML/WPFDesigner_XML.csproj
@@ -5,6 +5,7 @@
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -27,8 +28,8 @@
     <RootNamespace>WPFDesigner_XML</RootNamespace>
     <AssemblyName>WPFDesigner_XML</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <GeneratePkgDefFile>false</GeneratePkgDefFile>
-</PropertyGroup>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/WPFDesigner_XML/WPFDesigner_XML/source.extension.vsixmanifest
+++ b/WPFDesigner_XML/WPFDesigner_XML/source.extension.vsixmanifest
@@ -12,4 +12,7 @@
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
 </PackageManifest>


### PR DESCRIPTION
Two issues:
1. the project wasn't configured to produce .pkgdef
2. the .vsixmanifest file was missing assets config