### PR TITLE
Use project.json for SCC status bar sample

### DIFF
--- a/Source_Control_Provider_Status_Bar_Integration/C#/SccProvider.csproj
+++ b/Source_Control_Provider_Status_Bar_Integration/C#/SccProvider.csproj
@@ -75,28 +75,6 @@ PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.ImageCatalog" />
-    <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Embeddable">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0">
-      <EmbedInteropTypes>true</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Immutable.12.0" />
-    <Reference Include="Microsoft.VisualStudio.TextManager.Interop" />
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -229,6 +207,7 @@ PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="project.json" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/Source_Control_Provider_Status_Bar_Integration/C#/project.json
+++ b/Source_Control_Provider_Status_Bar_Integration/C#/project.json
@@ -1,0 +1,18 @@
+﻿{
+  "frameworks": {
+    "net45": { }
+  },
+  "dependencies": {
+    "Microsoft.VisualStudio.ImageCatalog": "14.1.24720",
+    "Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime": "14.1.24720",
+    "Microsoft.VisualStudio.SDK.EmbedInteropTypes": "14.1.2",
+    "Microsoft.VisualStudio.Shell.14.0": "14.2.25123",
+    "Microsoft.VisualStudio.Shell.Embeddable": "14.2.25123",
+    "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30110",
+    "Microsoft.VisualStudio.Threading": "14.1.114",
+    "Microsoft.VSSDK.BuildTools": "14.0.23205"
+  },
+  "runtimes": {
+    "win": { }
+  }
+}


### PR DESCRIPTION
This fixes the only project that doesn't otherwise build successfully without specific dependencies being installed on the machine.