### PR TITLE
Cache project.json restored packages for build speed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: 1.0.{build}
 image: Visual Studio 2015
 environment:
   DeployExtension: false
+cache:
+ - '%USERPROFILE%\.nuget\packages -> **\project.json'
 build_script:
 - ps: >-
     $failed = @()


### PR DESCRIPTION
Accelerate the AppVeyor build by caching the NuGet package cache between builds.