### PR TITLE
FIX: Missing Microsoft.VsSDK.targets in WPFDesigner_XML.csproj.

### DIFF
--- a/WPFDesigner_XML/WPFDesigner_XML/WPFDesigner_XML.csproj
+++ b/WPFDesigner_XML/WPFDesigner_XML/WPFDesigner_XML.csproj
@@ -130,4 +130,5 @@
     </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />  
 </Project>


### PR DESCRIPTION
The "Microsoft.VsSDK.targets" is missing in WPFDesigner_XML.csproj. Building WPFDesigner_XML.csproj only outputs an DLL.