### PR TITLE
Fixed missing "...\VSSDK\Microsoft.VsSDK.targets" import in *.csproj

### DIFF
--- a/LightBulb/TestLightBulb/TestLightBulb.csproj
+++ b/LightBulb/TestLightBulb/TestLightBulb.csproj
@@ -120,4 +120,5 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/MSDNSearch/C#/MSDNSearch/MSDNSearch.csproj
+++ b/MSDNSearch/C#/MSDNSearch/MSDNSearch.csproj
@@ -165,4 +165,5 @@ PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Ook_Language_Integration/C#/OokLanguage.csproj
+++ b/Ook_Language_Integration/C#/OokLanguage.csproj
@@ -116,4 +116,5 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Reference_Package/C#/Package.csproj
+++ b/Reference_Package/C#/Package.csproj
@@ -91,4 +91,5 @@ PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Reference_Services/C#/Reference.Services/Reference.Services.csproj
+++ b/Reference_Services/C#/Reference.Services/Reference.Services.csproj
@@ -101,4 +101,5 @@ PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Single_File_Generator/C#/GeneratorSample.csproj
+++ b/Single_File_Generator/C#/GeneratorSample.csproj
@@ -131,4 +131,5 @@ PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
     <RegisterWithCodebase>true</RegisterWithCodebase>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Source_Code_Control_Provider/C#/SccProvider.csproj
+++ b/Source_Code_Control_Provider/C#/SccProvider.csproj
@@ -218,4 +218,5 @@ PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Todo_Classification/C#/TodoClassification.csproj
+++ b/Todo_Classification/C#/TodoClassification.csproj
@@ -93,4 +93,5 @@
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Typing_Speed_Meter/C#/TypingSpeed.csproj
+++ b/Typing_Speed_Meter/C#/TypingSpeed.csproj
@@ -92,4 +92,5 @@
     </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/WPFDesigner_XML/WPFDesigner_XML/WPFDesigner_XML.csproj
+++ b/WPFDesigner_XML/WPFDesigner_XML/WPFDesigner_XML.csproj
@@ -130,4 +130,5 @@
     </Page>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Windows_Forms_Controls_Installer/C#/WinformsControlsInstaller/WinformsControlsInstaller.csproj
+++ b/Windows_Forms_Controls_Installer/C#/WinformsControlsInstaller/WinformsControlsInstaller.csproj
@@ -110,4 +110,5 @@ PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
Added the missing
`
  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />` 
in various projects which prevented the *.vsix from being build.