### PR TITLE
Move build script from appveyor.yml to build.ps1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,22 +6,4 @@ cache:
  - '%USERPROFILE%\.nuget\packages -> **\project.json'
 build_script:
 - ps: >-
-    $failed = @()
-
-    Get-ChildItem *.sln -rec |% {
-        Write-Output "Restoring packages for $($_.Name)"
-        nuget restore $_ -Verbosity quiet
-        if ($LASTEXITCODE -ne 0) {
-            $failed += $_
-        } else {
-            Write-Output "Building $($_.Name)"
-            msbuild $_ /nologo /m /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-            if ($LASTEXITCODE -ne 0) {
-                $failed += $_
-            }
-        }
-    }
-
-    if ($failed.length -gt 0) {
-        exit $failed.length
-    }
+    .\build.ps1

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,37 @@
+<#
+.Synopsis
+    Acquires dependencies and builds all solutions in this repo.
+.Parameter Configuration
+    The build configuration to build.
+#>
+[CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='Medium')]
+Param(
+    [ValidateSet('Debug','Release')]
+    $Configuration='Release'
+)
+
+
+$failed = @()
+
+$AppVeyorLogger = "$env:ProgramFiles\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+if (Test-Path $AppVeyorLogger) {
+    $Logger = "/logger:`"$AppVeyorLogger`""
+}
+
+Get-ChildItem $PSScriptRoot\*.sln -rec |% {
+    Write-Output "Restoring packages for $($_.Name)"
+    nuget restore $_ -Verbosity quiet
+    if ($LASTEXITCODE -ne 0) {
+        $failed += $_
+    } else {
+        Write-Output "Building $($_.Name)"
+        msbuild $_ /nologo /m /verbosity:minimal /p:Configuration=$Configuration $Logger
+        if ($LASTEXITCODE -ne 0) {
+            $failed += $_
+        }
+    }
+}
+
+if ($failed.length -gt 0) {
+    exit $failed.length
+}


### PR DESCRIPTION
This gives folks preparing changes a way to validate the entire repo builds properly, just as it does in AppVeyor. It's also easier to test changes to the build script locally to avoid testing it by pushing to appveyor first.

I verified that [a build break is still recognized as a break by AppVeyor](https://ci.appveyor.com/project/AArnott/vssdk-extensibility-samples/build/1.0.42) and [the build can still succeed when there are no compiler errors](https://ci.appveyor.com/project/AArnott/vssdk-extensibility-samples/build/1.0.41).