### PR TITLE
Reference correct BuildTools version

### DIFF
--- a/Open_Folder_Extensibility/C#/packages.config
+++ b/Open_Folder_Extensibility/C#/packages.config
@@ -18,5 +18,5 @@
   <package id="Microsoft.VisualStudio.Validation" version="15.0.11-pre" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Workspace.VSIntegration" version="15.0.215-pre" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Workspaces" version="15.0.215-pre" targetFramework="net46" />
-  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26109-RC3" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Open_Folder_Extensibility/C#/packages.config
+++ b/Open_Folder_Extensibility/C#/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26109-RC3" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Imaging" version="15.0.26109-RC3" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Imaging" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.OLE.Interop" version="7.10.6070" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26109-RC3" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26109-RC3" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.15.0" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Shell.Framework" version="15.0.26201" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.Interop" version="7.10.6071" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.Interop.10.0" version="10.0.30319" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Shell.Interop.11.0" version="11.0.61030" targetFramework="net46" />
@@ -13,9 +13,9 @@
   <package id="Microsoft.VisualStudio.Shell.Interop.9.0" version="9.0.30729" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.TextManager.Interop" version="7.10.6070" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.TextManager.Interop.8.0" version="8.0.50727" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Threading" version="15.0.20-pre" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26109-RC3" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.Validation" version="15.0.11-pre" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Threading" version="15.0.240" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Utilities" version="15.0.26201" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.Validation" version="15.0.82" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Workspace.VSIntegration" version="15.0.215-pre" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Workspaces" version="15.0.215-pre" targetFramework="net46" />
   <package id="Microsoft.VSSDK.BuildTools" version="15.0.26201" targetFramework="net46" developmentDependency="true" />


### PR DESCRIPTION
The project was looking for 15.0.26201 but the package referred to was 15.0.26109-RC3. The fix is to update the package reference to 15.0.26201.