### PR TITLE
Update the sample for 16.1

### DIFF
--- a/CodeLensOopSample/README.md
+++ b/CodeLensOopSample/README.md
@@ -1,7 +1,7 @@
 # CodeLensOopProvider example 
 A example for demonstrating how to use the public CodeLens API to create an out-of-proc extesnion that provides a CodeLens indictor showing most recent Git commits made to the source code.
 
-* Technologies: Visual Studio 2017 SDK
+* Technologies: Visual Studio 2019 SDK
 * Topics: CodeLens
 
 **Description**
@@ -14,7 +14,7 @@ This example generates a VSIX extension that packs two components:
 
 **Requirements**
 
-The example requires Visual Studio 2017 15.8 Preview 3 and above versions, Community SKU and above.
+The example requires Visual Studio 2019 16.1 and above versions, Community SKU and above.
 
 **Getting Started**
 

--- a/CodeLensOopSample/src/CodeLensOopProvider/CodeLensOopProvider.csproj
+++ b/CodeLensOopSample/src/CodeLensOopProvider/CodeLensOopProvider.csproj
@@ -10,10 +10,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CodeLensOopProvider</RootNamespace>
     <AssemblyName>CodeLensOopProvider</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,44 +37,105 @@
     <Reference Include="LibGit2Sharp, Version=0.24.1.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
       <HintPath>..\..\packages\LibGit2Sharp.0.24.1\lib\net40\LibGit2Sharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.CoreUtility.15.8.414-preview\lib\net46\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.CoreUtility.16.1.89\lib\net472\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Language, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.Language.15.8.414-preview\lib\net46\Microsoft.VisualStudio.Language.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Language, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Language.16.1.89\lib\net472\Microsoft.VisualStudio.Language.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.Data.15.8.414-preview\lib\net46\Microsoft.VisualStudio.Text.Data.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.Data.16.1.89\lib\net472\Microsoft.VisualStudio.Text.Data.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.Logic.15.8.414-preview\lib\net46\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.Logic.16.1.89\lib\net472\Microsoft.VisualStudio.Text.Logic.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.UI.15.8.414-preview\lib\net46\Microsoft.VisualStudio.Text.UI.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Text.UI.16.1.89\lib\net472\Microsoft.VisualStudio.Text.UI.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.15.3.23\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Threading.16.0.102\lib\net46\Microsoft.VisualStudio.Threading.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Validation, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Validation.15.3.15\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
     </Reference>
+    <Reference Include="Nerdbank.Streams, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cac503e1823ce71c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Nerdbank.Streams.2.1.37\lib\net472\Nerdbank.Streams.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="StreamJsonRpc, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\StreamJsonRpc.1.3.6\lib\net45\StreamJsonRpc.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="StreamJsonRpc, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StreamJsonRpc.2.0.167\lib\net472\StreamJsonRpc.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Pipelines, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Pipelines.4.5.3\lib\netstandard2.0\System.IO.Pipelines.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.2\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.Http.4.3.3\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.WebSockets, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Net.WebSockets.4.3.0\lib\net46\System.Net.WebSockets.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/CodeLensOopSample/src/CodeLensOopProvider/GitCommitDataPointProvider.cs
+++ b/CodeLensOopSample/src/CodeLensOopProvider/GitCommitDataPointProvider.cs
@@ -162,7 +162,7 @@ namespace CodeLensOopProvider
                             {
                                 CommandSet = new Guid("57735D06-C920-4415-A2E0-7D6E6FBDFA99"),
                                 CommandId = 0x1005,
-                                CommandName = "Git.NavigateToCommit",
+                                CommandName = "Git.ShowHistory",
                             },
                             CommandDisplayName = "Show History"
                         }

--- a/CodeLensOopSample/src/CodeLensOopProvider/GitCommitDataPointProvider.cs
+++ b/CodeLensOopSample/src/CodeLensOopProvider/GitCommitDataPointProvider.cs
@@ -1,5 +1,6 @@
 ﻿using LibGit2Sharp;
 using Microsoft.VisualStudio.Core.Imaging;
+using Microsoft.VisualStudio.Language.CodeLens;
 using Microsoft.VisualStudio.Language.CodeLens.Remoting;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
@@ -23,14 +24,14 @@ namespace CodeLensOopProvider
     {
         internal const string Id = "GitCommit";
 
-        public Task<bool> CanCreateDataPointAsync(CodeLensDescriptor descriptor, CancellationToken token)
+        public Task<bool> CanCreateDataPointAsync(CodeLensDescriptor descriptor, CodeLensDescriptorContext context, CancellationToken token)
         {
             Debug.Assert(descriptor != null);
             var gitRepo = GitUtil.ProbeGitRepository(descriptor.FilePath, out string repoRoot);
             return Task.FromResult<bool>(gitRepo != null);
         }
 
-        public Task<IAsyncCodeLensDataPoint> CreateDataPointAsync(CodeLensDescriptor descriptor, CancellationToken token)
+        public Task<IAsyncCodeLensDataPoint> CreateDataPointAsync(CodeLensDescriptor descriptor, CodeLensDescriptorContext context, CancellationToken token)
         {
             return Task.FromResult<IAsyncCodeLensDataPoint>(new GitCommitDataPoint(descriptor));
         }
@@ -51,7 +52,7 @@ namespace CodeLensOopProvider
 
             public CodeLensDescriptor Descriptor => this.descriptor;
 
-            public Task<CodeLensDataPointDescriptor> GetDataAsync(CancellationToken token)
+            public Task<CodeLensDataPointDescriptor> GetDataAsync(CodeLensDescriptorContext context, CancellationToken token)
             {
                 // get the most recent commit
                 Commit commit = GitUtil.GetCommits(this.gitRepo, this.descriptor.FilePath, 1).FirstOrDefault();
@@ -71,7 +72,7 @@ namespace CodeLensOopProvider
                 return Task.FromResult(response);
             }
 
-            public Task<CodeLensDetailsDescriptor> GetDetailsAsync(CancellationToken token)
+            public Task<CodeLensDetailsDescriptor> GetDetailsAsync(CodeLensDescriptorContext context, CancellationToken token)
             {
                 // get the most recent 5 commits
                 var commits = GitUtil.GetCommits(this.gitRepo, this.descriptor.FilePath, 5).AsEnumerable();
@@ -157,7 +158,13 @@ namespace CodeLensOopProvider
                     {
                         new CodeLensDetailPaneCommand()
                         {
-                            CommandDisplayName = "Show History",
+                            CommandId = new CodeLensDetailEntryCommand()
+                            {
+                                CommandSet = new Guid("57735D06-C920-4415-A2E0-7D6E6FBDFA99"),
+                                CommandId = 0x1005,
+                                CommandName = "Git.NavigateToCommit",
+                            },
+                            CommandDisplayName = "Show History"
                         }
                     },
                 };

--- a/CodeLensOopSample/src/CodeLensOopProvider/Resources.Designer.cs
+++ b/CodeLensOopSample/src/CodeLensOopProvider/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace CodeLensOopProvider {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/CodeLensOopSample/src/CodeLensOopProvider/app.config
+++ b/CodeLensOopSample/src/CodeLensOopProvider/app.config
@@ -10,6 +10,18 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.Threading" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-16.0.0.0" newVersion="16.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/CodeLensOopSample/src/CodeLensOopProvider/packages.config
+++ b/CodeLensOopSample/src/CodeLensOopProvider/packages.config
@@ -2,23 +2,37 @@
 <packages>
   <package id="LibGit2Sharp" version="0.24.1" targetFramework="net461" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.205" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.CoreUtility" version="15.8.414-preview" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Language" version="15.8.414-preview" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Text.Data" version="15.8.414-preview" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Text.Logic" version="15.8.414-preview" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Text.UI" version="15.8.414-preview" targetFramework="net461" />
-  <package id="Microsoft.VisualStudio.Threading" version="15.3.23" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.CoreUtility" version="16.1.89" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Language" version="16.1.89" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Text.Data" version="16.1.89" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Text.Logic" version="16.1.89" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Text.UI" version="16.1.89" targetFramework="net472" />
+  <package id="Microsoft.VisualStudio.Threading" version="16.0.102" targetFramework="net472" />
   <package id="Microsoft.VisualStudio.Validation" version="15.3.15" targetFramework="net461" />
+  <package id="Nerdbank.Streams" version="2.1.37" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="StreamJsonRpc" version="1.3.23" targetFramework="net461" />
+  <package id="StreamJsonRpc" version="2.0.167" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
   <package id="System.Collections" version="4.0.11" targetFramework="net461" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net461" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
   <package id="System.Globalization" version="4.0.11" targetFramework="net461" />
-  <package id="System.IO" version="4.1.0" targetFramework="net461" />
-  <package id="System.Linq" version="4.1.0" targetFramework="net461" />
-  <package id="System.Runtime" version="4.1.0" targetFramework="net461" />
+  <package id="System.IO" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Pipelines" version="4.5.3" targetFramework="net472" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net461" requireReinstallation="true" />
+  <package id="System.Memory" version="4.5.2" targetFramework="net472" />
+  <package id="System.Net.Http" version="4.3.3" targetFramework="net472" />
+  <package id="System.Net.WebSockets" version="4.3.0" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
+  <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net472" />
   <package id="System.Threading" version="4.0.11" targetFramework="net461" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/CodeLensOopSample/src/CodeLensOopProviderVsix.csproj
+++ b/CodeLensOopSample/src/CodeLensOopProviderVsix.csproj
@@ -73,9 +73,6 @@
     <Content Include="Resources\CodeLensOopProviderPackage.ico" />
   </ItemGroup>
   <ItemGroup>
-    <SuppressFromVSIX Include="Microsoft.VisualStudio.Language.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
@@ -195,16 +192,14 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.7.4\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.7.17\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="CodeLensOopProvider\CodeLensOopProvider.csproj">
       <Project>{31eb1b96-34e8-4e37-872d-4ed7363c95d9}</Project>
       <Name>CodeLensOopProvider</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3bDebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
-      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.7.4\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.7.17\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />


### PR DESCRIPTION
There were breaking changes to CodeLens API in 16.1 because previous API has major design flaw making it mostly unusable.
Updating OOP CodeLens sample for 16.1 and StreamJsonRpc 2.0, as well minor improvement - actually make Show History command in the CodeLens popup work.