### PR TITLE
Fix the lack of Highlight_Word

### DIFF
--- a/Highlight_Word/C#/HighlightWordTagger.cs
+++ b/Highlight_Word/C#/HighlightWordTagger.cs
@@ -16,7 +16,9 @@ namespace HighlightWordSample
     using System.ComponentModel.Composition;
     using System.Linq;
     using System.Threading;
+    using System.Windows.Media;
     using Microsoft.VisualStudio.Text;
+    using Microsoft.VisualStudio.Text.Classification;
     using Microsoft.VisualStudio.Text.Editor;
     using Microsoft.VisualStudio.Text.Operations;
     using Microsoft.VisualStudio.Text.Tagging;
@@ -28,7 +30,24 @@ namespace HighlightWordSample
     /// </summary>
     public class HighlightWordTag : TextMarkerTag 
     { 
-        public HighlightWordTag() : base("blue") { }
+        public HighlightWordTag() : base("MarkerFormatDefinition/HighlightWordFormatDefinition") { }
+    }
+    
+    /// <summary>
+    /// Drive from MarkerFormatDefinition, in case anyone wants to decorate 
+    /// just the HighlightWordTags by themselves
+    /// </summary>
+    [Export(typeof(EditorFormatDefinition))]
+    [Name("MarkerFormatDefinition/HighlightWordFormatDefinition")]
+    [UserVisible(true)]
+    internal class HighlightWordFormatDefinition : MarkerFormatDefinition
+    {
+        public HighlightWordFormatDefinition()
+        {
+            this.ForegroundColor = Colors.Red;
+            this.DisplayName = "Highlight Word";
+            this.ZOrder = 5;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
According to the  [`Walkthrough: Highlight text`](https://docs.microsoft.com/en-us/visualstudio/extensibility/walkthrough-highlighting-text?view=vs-2019#define-a-textmarkertag),We have to write this.
```C#
[Export(typeof(EditorFormatDefinition))] [Name("MarkerFormatDefinition/HighlightWordFormatDefinition")]
[UserVisible(true)]
internal class HighlightWordFormatDefinition : MarkerFormatDefinitio
{
    public HighlightWordFormatDefinition()
    {
        this.ForegroundColor = Colors.Red;
        this.DisplayName = "Highlight Word";
        this.ZOrder = 5;
    }
}
```
but this example hasn't this.
So I added this code to the example.